### PR TITLE
Fully operational README and a convenience method. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Phenotype phenotype = new Phenotype();
 phenotype.setTypes(ImmutableList.of(
         new OntologyClass.Builder("HP:0000272").setLabel("Malar flattening").build()
 ));
-# Typically an observation is accompanied with some kind of evidence attribution - here we have a journal
+// Typically an observation is accompanied with some kind of evidence attribution - here we have a journal
 Evidence journalEvidence = new Evidence();
         journalEvidence.setTypes(ImmutableList.of(new OntologyClass.Builder(("ECO:0000033").setLabel("TAS").build()));
         Publication pub = new Publication.Builder().setId("PMID:23455423").build();
         journalEvidence.setSupportingPublications(ImmutableList.of(pub));
-# These are then linked with a PhenotypeAssociation
+// These are then linked with a PhenotypeAssociation
 PhenotypeAssociation patientPhenotypeAssociation = new PhenotypeAssociation.Builder(phenotype)
         .setEntity(person)
         .addEvidence(journalEvidence)

--- a/README.md
+++ b/README.md
@@ -15,21 +15,23 @@ in general.
 # Including phenopackets-api in your code:
 ## Maven
 ```xml
-    <dependency>
-        <groupId>org.phenopackets</groupId>
-        <artifactId>phenopackets-api</artifactId>
-        <version>${project.version}</version>
-    </dependency>
+<dependency>
+    <groupId>org.phenopackets</groupId>
+    <artifactId>phenopackets-api</artifactId>
+    <version>${project.version}</version>
+</dependency>
 ```
 
 ## Gradle
 ```groovy
-    compile 'org.phenopackets:phenopackets-api:${project.version}'
+compile 'org.phenopackets:phenopackets-api:${project.version}'
 ```
 
 # Using it
 
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.phenopackets/phenopackets-api/badge.svg)](http://www.javadoc.io/doc/org.phenopackets/phenopackets-api)
+Most of these examples have been taken from the [test](https://github.com/phenopackets/phenopacket-reference-implementation/tree/master/src/test) package.
+Check there for more thorough examples. 
 
 ### Reading a JSON/YAML file
 ```java
@@ -47,6 +49,48 @@ PhenoPacket phenoPacket = new PhenoPacket.Builder()
                 .title("Empty phenopacket")
                 .build();
 ```
+### Creating Entities
+Entities refer to things such as individuals of an organism/people, variants or diseases. For example here is a new Person:
+```java
+Person person = new Person();
+person.setId("person#1");
+person.setLabel("Joe Bloggs");
+person.setSex("M");
+```
+
+### Associating Entities with Conditions
+Entities can have associated Conditions. A Condition is usually defined with a phenotype, location, time of onset/offset
+the severity and the environment in which this condition was observed. Entities and Conditions are linked by an Association.
+Associations are also immutable objects which use a Builder. 
+
+Here we're going to associate a phenotype from the [HPO](http://human-phenotype-ontology.org) with the person from the previous example.
+```java
+Phenotype phenotype = new Phenotype();
+phenotype.setTypes(ImmutableList.of(
+        new OntologyClass.Builder("HP:0000272").setLabel("Malar flattening").build()
+));
+# Typically an observation is accompanied with some kind of evidence attribution - here we have a journal
+Evidence journalEvidence = new Evidence();
+        journalEvidence.setTypes(ImmutableList.of(new OntologyClass.Builder(("ECO:0000033").setLabel("TAS").build()));
+        Publication pub = new Publication.Builder().setId("PMID:23455423").build();
+        journalEvidence.setSupportingPublications(ImmutableList.of(pub));
+# These are then linked with a PhenotypeAssociation
+PhenotypeAssociation patientPhenotypeAssociation = new PhenotypeAssociation.Builder(phenotype)
+        .setEntity(person)
+        .addEvidence(journalEvidence)
+        .build();
+```
+### Adding Entities and Associations to a PhenoPacket
+Using the API it s now trivial to create a phenopacket containing the person and their observed phenotype. 
+```java
+PhenoPacket pk = new PhenoPacket.Builder()
+                .id(id)
+                .title("Patient with a phenotype")
+                .addPerson(person)
+                .addPhenotypeAssociation(patientPhenotypeAssociation)
+                .build();
+```
+
 ### Writing to JSON/YAML
 ```java
 PhenoPacket phenoPacket ...

--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ disease.setTypes(phenotypes);
 ### Conditions
 A Condition is usually defined with a phenotype, location, time of onset/offset
 the severity and the environment in which this condition was observed. A condition could simply be a phenotype - here is 
-one from the [HPO](http://human-phenotype-ontology.org) 
+one from the [HPO](http://human-phenotype-ontology.org), with a negative type too (i.e. this was tested for and not observed).
 ```java
 Phenotype phenotype = new Phenotype();
 phenotype.setTypes(ImmutableList.of(
         OntologyClass.of("HP:0000272", "Malar flattening")
+));
+phenotype.setNegatedTypes(ImmutableList.of(
+        OntologyClass.of("HP:0001249", "Intellectual disability")
 ));
 ```
 or an occurrence of a disease
@@ -108,7 +111,6 @@ Associations are also immutable objects which use a Builder.
 
 Here we're going to associate the phenotype with the person from the previous examples.
 ```java
-// These are then linked with a PhenotypeAssociation
 PhenotypeAssociation patientPhenotypeAssociation = new PhenotypeAssociation.Builder(phenotype)
         .setEntity(person)
         .addEvidence(journalEvidence)
@@ -116,7 +118,9 @@ PhenotypeAssociation patientPhenotypeAssociation = new PhenotypeAssociation.Buil
 ```
 and the Disease with the DiseaseAssociation.
 ```java
-DiseaseOccurrenceAssociation association = new DiseaseOccurrenceAssociation.Builder(diseaseOccurrence).setEntity(disease).build();
+DiseaseOccurrenceAssociation association = new DiseaseOccurrenceAssociation.Builder(diseaseOccurrence)
+        .setEntity(disease)
+        .build();
 ```
 ### Adding Entities and Associations to a PhenoPacket
 Using the API it s now trivial to create a phenopacket containing the person and their observed phenotype. 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # Phenopackets/PXF Reference Implementation
 
-See https://github.com/phenopackets/phenopacket-format/ and the src/test/resources package of this repo for examples of 
-the input and output formats and https://github.com/phenopackets/phenopacket-format/wiki for more details on the project 
-in general.
-
 This project provides a reference java implementation for the Phenotype eXchange Format (PXF). Jackson annotations are 
 used to describe the mapping to the JSON serialization of PXF. We are also experimenting with generating the JSON Schema 
 from the reference implementation.
+
+See [Phenopcket-format repo](https://github.com/phenopackets/phenopacket-format) and the [src/test/resources](https://github.com/phenopackets/phenopacket-reference-implementation/tree/master/src/test/resources) package of this repo for examples of 
+the input and output formats. [Phenopcket-format wiki](https://github.com/phenopackets/phenopacket-format/wiki) contains more details on the project 
+in general.
 
 # Including phenopackets-api in your code:
 ## Maven
@@ -29,7 +29,26 @@ from the reference implementation.
 
 # Using it
 
-Javadoc: [org.phenopackets/phenopackets-api](http://www.javadoc.io/doc/org.phenopackets/phenopackets-api)
+[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.phenopackets/phenopackets-api/badge.svg)](http://www.javadoc.io/doc/org.phenopackets/phenopackets-api)
 
-Need some code examples here...
+### Reading a JSON/YAML file
+```java
+PhenoPacket phenoPacket = YamlReader.readFile("phenopacket.yaml");
+```
 
+### Creating a Phenopacket
+Where possible the Builder pattern is used to provide a fluent API for building objects and create immutable instances. 
+The PhenoPacket class is immutable, although instances of classes from the org.phenopackets.api.model.condition and 
+org.phenopackets.api.model.entity package are not.
+
+```java
+PhenoPacket phenoPacket = new PhenoPacket.Builder()
+                .id("PXF:000001")
+                .title("Empty phenopacket")
+                .build();
+```
+### Writing to JSON/YAML
+```java
+PhenoPacket phenoPacket ...
+String yamlString = YamlGenerator.render(phenoPacket);
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This project provides a reference java implementation for the Phenotype eXchange
 used to describe the mapping to the JSON serialization of PXF. We are also experimenting with generating the JSON Schema 
 from the reference implementation.
 
-See [Phenopcket-format repo](https://github.com/phenopackets/phenopacket-format) and the [src/test/resources](https://github.com/phenopackets/phenopacket-reference-implementation/tree/master/src/test/resources) package of this repo for examples of 
-the input and output formats. [Phenopcket-format wiki](https://github.com/phenopackets/phenopacket-format/wiki) contains more details on the project 
+See [phenopacket-format repo](https://github.com/phenopackets/phenopacket-format) and the [src/test/resources](https://github.com/phenopackets/phenopacket-reference-implementation/tree/master/src/test/resources) package of this repo for examples of 
+the serialised JSON and YAML formats. The phenopacket-format repo [wiki](https://github.com/phenopackets/phenopacket-format/wiki) contains more details on the project 
 in general.
 
 # Including phenopackets-api in your code:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PhenoPacket phenoPacket = new PhenoPacket.Builder()
                 .title("Empty phenopacket")
                 .build();
 ```
-### Creating Entities
+### Entities
 Entities refer to things such as individuals of an organism/people, variants or diseases. For example here is a new Person:
 ```java
 Person person = new Person();
@@ -57,28 +57,66 @@ person.setId("person#1");
 person.setLabel("Joe Bloggs");
 person.setSex("M");
 ```
+here is the disease Pfeiffer syndrome
+```java
+Disease disease = new Disease();
+disease.setId("OMIM:101600");
+disease.setLabel("Pfeiffer syndrome");
+List<OntologyClass> phenotypes = ImmutableList.of(
+        OntologyClass.of("HP:0000272", "Malar flattening"),
+        OntologyClass.of("HP:0005347", "Cartilaginous trachea"),
+        OntologyClass.of("HP:0001249", "Intellectual disability"),
+        OntologyClass.of("HP:0005048", "Synostosis of carpal bones"),
+        OntologyClass.of("HP:0004440", "Coronal craniosynostosis"),
+        OntologyClass.of("HP:0001156", "Brachydactyly syndrome")
+);
+disease.setTypes(phenotypes);
+```
 
-### Associating Entities with Conditions
-Entities can have associated Conditions. A Condition is usually defined with a phenotype, location, time of onset/offset
-the severity and the environment in which this condition was observed. Entities and Conditions are linked by an Association.
-Associations are also immutable objects which use a Builder. 
-
-Here we're going to associate a phenotype from the [HPO](http://human-phenotype-ontology.org) with the person from the previous example.
+### Conditions
+A Condition is usually defined with a phenotype, location, time of onset/offset
+the severity and the environment in which this condition was observed. A condition could simply be a phenotype - here is 
+one from the [HPO](http://human-phenotype-ontology.org) 
 ```java
 Phenotype phenotype = new Phenotype();
 phenotype.setTypes(ImmutableList.of(
-        new OntologyClass.Builder("HP:0000272").setLabel("Malar flattening").build()
+        OntologyClass.of("HP:0000272", "Malar flattening")
 ));
-// Typically an observation is accompanied with some kind of evidence attribution - here we have a journal
+```
+or an occurrence of a disease
+```java
+DiseaseOccurrence diseaseOccurrence = new DiseaseOccurrence();
+DiseaseStage stage = new DiseaseStage();
+stage.setDescription("Childhood onset");
+stage.setTypes(ImmutableList.of(
+        OntologyClass.of("HP:0011463", "Childhood onset")
+));
+diseaseOccurrence.setStage(stage);
+```
+
+Typically an observation is accompanied with some kind of evidence attribution - here we have a journal
+```java
 Evidence journalEvidence = new Evidence();
-        journalEvidence.setTypes(ImmutableList.of(new OntologyClass.Builder(("ECO:0000033").setLabel("TAS").build()));
-        Publication pub = new Publication.Builder().setId("PMID:23455423").build();
-        journalEvidence.setSupportingPublications(ImmutableList.of(pub));
+journalEvidence.setTypes(ImmutableList.of(OntologyClass.of("ECO:0000033", "TAS")));
+Publication pub = new Publication.Builder().setId("PMID:23455423").build();
+journalEvidence.setSupportingPublications(ImmutableList.of(pub));
+```
+
+### Associating Entities with Conditions
+Entities can have associated Conditions.Entities and Conditions are linked by an Association.
+Associations are also immutable objects which use a Builder. 
+
+Here we're going to associate the phenotype with the person from the previous examples.
+```java
 // These are then linked with a PhenotypeAssociation
 PhenotypeAssociation patientPhenotypeAssociation = new PhenotypeAssociation.Builder(phenotype)
         .setEntity(person)
         .addEvidence(journalEvidence)
         .build();
+```
+and the Disease with the DiseaseAssociation.
+```java
+DiseaseOccurrenceAssociation association = new DiseaseOccurrenceAssociation.Builder(diseaseOccurrence).setEntity(disease).build();
 ```
 ### Adding Entities and Associations to a PhenoPacket
 Using the API it s now trivial to create a phenopacket containing the person and their observed phenotype. 
@@ -88,6 +126,15 @@ PhenoPacket pk = new PhenoPacket.Builder()
                 .title("Patient with a phenotype")
                 .addPerson(person)
                 .addPhenotypeAssociation(patientPhenotypeAssociation)
+                .build();
+```
+or a disease as characterised by its associated pehnotypes and its time of onset
+```java
+PhenoPacket pk = new PhenoPacket.Builder()
+                .id(id)
+                .title("Description of a disease and its time of onset")
+                .addDisease(disease)
+                .addDiseaseOccurrenceAssociation(diseaseOccurrenceAssociation)
                 .build();
 ```
 

--- a/src/main/java/org/phenopackets/api/model/condition/TemporalRegion.java
+++ b/src/main/java/org/phenopackets/api/model/condition/TemporalRegion.java
@@ -27,7 +27,7 @@ import org.phenopackets.api.model.ontology.ClassInstance;
  *     [    TR1   ]>>>>>>>>>>>>>>>>>>>>>>>>[         TR2        ]
  * </pre>
  * <p/>
- * Where tr1s is the {@link TemporalRegion.getStartTime()} of TR1, etc.
+ * Where tr1s is the {@link TemporalRegion#getStartTime()} of TR1, etc.
  * Note that the duration the organism has the phenotype is <code>tr2e-tr1s</code>
  * <p/>
  * This allows us an arbitrary degree of fuzziness when recording onset and offset.

--- a/src/main/java/org/phenopackets/api/model/ontology/OntologyClass.java
+++ b/src/main/java/org/phenopackets/api/model/ontology/OntologyClass.java
@@ -89,4 +89,15 @@ public class OntologyClass {
             return new OntologyClass(this);
         }
     }
+
+    /**
+     * Convenience static factory method to remove some of the {@link Builder} verbosity at the expense of getting the id
+     * and label switched the wrong way round. Use at your own risk.
+     * @param id
+     * @param label
+     * @return
+     */
+    public static OntologyClass of(String id, String label) {
+        return new Builder(id).setLabel(label).build();
+    };
 }

--- a/src/test/java/org/phenopackets/api/PhenoPacketTest.java
+++ b/src/test/java/org/phenopackets/api/PhenoPacketTest.java
@@ -38,7 +38,7 @@ public class PhenoPacketTest {
      * @return
      */
     private OntologyClass ontologyClass(String id, String label) {
-        return new OntologyClass.Builder(id).setLabel(label).build();
+        return OntologyClass.of(id, label);
     }
 
     private Person getPerson() {

--- a/src/test/java/org/phenopackets/api/model/ontology/OntologyClassTest.java
+++ b/src/test/java/org/phenopackets/api/model/ontology/OntologyClassTest.java
@@ -1,0 +1,30 @@
+package org.phenopackets.api.model.ontology;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jules Jacobsen <jules.jacobsen@sanger.ac.uk>
+ */
+public class OntologyClassTest {
+
+    @Test
+    public void testBuilder() {
+        String id = "id";
+        String label = "term";
+        OntologyClass ontologyClass = new OntologyClass.Builder(id).setLabel(label).build();
+        assertThat(ontologyClass.getId(), equalTo(id));
+        assertThat(ontologyClass.getLabel(), equalTo(label));
+    }
+
+    @Test
+    public void testConvenienceStaticFactoryMethod() {
+        String id = "id";
+        String label = "term";
+        OntologyClass fromBuilder = new OntologyClass.Builder(id).setLabel(label).build();
+        OntologyClass fromOf = OntologyClass.of(id, label);
+        assertThat(fromOf, equalTo(fromBuilder));
+    }
+}


### PR DESCRIPTION
Added a ton of code examples. Hopefully these won't get out of sync with the codebase. I figure most people would want some kind of a quick demo of what's required and where to look, so added it all in the README.

Doing this made me sick of typing ```new OntologyClass.Builder(id).setLabel(label).build()``` so wrapped that in a new method on Ontology class ```OntologyClass.of(id, label)```. It's not a safe thing to do from the type or change perspective, but it's way more convenient for coding things. Maybe I should have added a  ```OntologyClass.of(id)``` method too? 