### PR TITLE
Added methods for reading from input stream.

### DIFF
--- a/src/main/java/org/phenopackets/api/io/JsonReader.java
+++ b/src/main/java/org/phenopackets/api/io/JsonReader.java
@@ -1,19 +1,27 @@
 package org.phenopackets.api.io;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.phenopackets.api.PhenoPacket;
-
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+
+import org.phenopackets.api.PhenoPacket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonReader {
-	
+
 	public static PhenoPacket readFile(String fileName) throws IOException {
 		return readFile(new File(fileName));
 	}
+
 	public static PhenoPacket readFile(File file) throws IOException {
 		ObjectMapper objectMapper = new ObjectMapper();
 		return objectMapper.readValue(file, PhenoPacket.class);
 	}
 
+	public static PhenoPacket readInputStream(InputStream stream) throws IOException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		return objectMapper.readValue(stream, PhenoPacket.class);
+	}
+	
 }

--- a/src/main/java/org/phenopackets/api/io/YamlReader.java
+++ b/src/main/java/org/phenopackets/api/io/YamlReader.java
@@ -1,20 +1,28 @@
 package org.phenopackets.api.io;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.phenopackets.api.PhenoPacket;
-
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+
+import org.phenopackets.api.PhenoPacket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class YamlReader {
 	
 	public static PhenoPacket readFile(String fileName) throws IOException {
 		return readFile(new File(fileName));
 	}
+	
 	public static PhenoPacket readFile(File file) throws IOException {
 		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 		return objectMapper.readValue(file, PhenoPacket.class);
+	}
+	
+	public static PhenoPacket readInputStream(InputStream stream) throws IOException {
+		ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+		return objectMapper.readValue(stream, PhenoPacket.class);
 	}
 
 }


### PR DESCRIPTION
I expect that pxftools will want to be able to read from stdin. I added methods to the JSON and YAML readers to handle an InputStream. I wasn't sure whether it was best to overload readFile or make a separate method—since ObjectMapper already handles both I decided to make a separate readInputStream and call the alternative in ObjectMapper directly.