### PR TITLE
Fixed warnings caused by missing generics.

### DIFF
--- a/src/main/java/org/phenopackets/api/PhenoPacket.java
+++ b/src/main/java/org/phenopackets/api/PhenoPacket.java
@@ -72,7 +72,7 @@ public class PhenoPacket {
      * @param list
      * @return
      */
-    private ImmutableList nullIfEmptyOrImmutableList(List list) {
+    private <T> ImmutableList<T> nullIfEmptyOrImmutableList(List<T> list) {
         return list.isEmpty() ? null : ImmutableList.copyOf(list);
     }
 


### PR DESCRIPTION
A tiny change to make the compiler happier.