### PR TITLE
Updates for local snapshot usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ in general.
 compile 'org.phenopackets:phenopackets-api:${project.version}'
 ```
 
+## Installing a development snapshot
+When developing against an unreleased snapshot version of the API, you can use Maven to install it in your local m2 repository:
+
+```
+mvn -Dgpg.skip install
+```
+
 # Using it
 
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.phenopackets/phenopackets-api/badge.svg)](http://www.javadoc.io/doc/org.phenopackets/phenopackets-api)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.phenopackets</groupId>
     <artifactId>phenopackets-api</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Reference implementation for the Phenopackets specification</description>


### PR DESCRIPTION
Updated version to 0.0.4-SNAPSHOT, and updated README to show `mvn install` without using GPG.