### PR TITLE
Failing test of JSON roundtrip (now with fix)

### DIFF
--- a/src/main/java/org/phenopackets/api/PhenoPacket.java
+++ b/src/main/java/org/phenopackets/api/PhenoPacket.java
@@ -115,6 +115,7 @@ public class PhenoPacket {
      * @return the phenotype_profile
      */
     @JsonInclude(Include.NON_EMPTY)
+    @JsonProperty("phenotype_profile")
     public List<PhenotypeAssociation> getPhenotypeAssociations() {
         return phenotypeAssociations;
     }
@@ -123,11 +124,13 @@ public class PhenoPacket {
      * @return the diseaseOccurrenceAssociations
      */
     @JsonInclude(Include.NON_EMPTY)
+    @JsonProperty("diagnosis_profile")
     public List<DiseaseOccurrenceAssociation> getDiseaseOccurrenceAssociations() {
         return diseaseOccurrenceAssociations;
     }
 
     @JsonInclude(Include.NON_EMPTY)
+    @JsonProperty("environment_profile")
     public List<EnvironmentAssociation> getEnvironmentAssociations() {
         return environmentAssociations;
     }

--- a/src/main/java/org/phenopackets/api/PhenoPacket.java
+++ b/src/main/java/org/phenopackets/api/PhenoPacket.java
@@ -31,9 +31,11 @@ import com.google.common.collect.ImmutableList;
 public class PhenoPacket {
 
     @JsonldId
+    @JsonProperty("id")
     private final String id;
 
     @JsonldProperty("http://purl.org/dc/elements/1.1/title")
+    @JsonProperty("title")
     private final String title;
 
     /*

--- a/src/test/java/org/phenopackets/api/io/JsonGeneratorTest.java
+++ b/src/test/java/org/phenopackets/api/io/JsonGeneratorTest.java
@@ -15,7 +15,7 @@ import org.phenopackets.api.model.ontology.OntologyClass;
 public class JsonGeneratorTest {
 
 	private PhenoPacket makePhenoPacket() {
-
+		
         Disease disease = new Disease();
         disease.setId("OMIM:101600");
         disease.setLabel("Pfeiffer syndrome");
@@ -26,6 +26,8 @@ public class JsonGeneratorTest {
 
 		PhenotypeAssociation pa = new PhenotypeAssociation.Builder(p).setEntity(disease).build();
         return new PhenoPacket.Builder()
+        		.id("EX:1234")
+        		.title("A phenopacket for testing roundtrip")
                 .addDisease(disease)
                 .addPhenotypeAssociation(pa)
                 .build();

--- a/src/test/java/org/phenopackets/api/io/JsonGeneratorTest.java
+++ b/src/test/java/org/phenopackets/api/io/JsonGeneratorTest.java
@@ -1,0 +1,42 @@
+package org.phenopackets.api.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.phenopackets.api.PhenoPacket;
+import org.phenopackets.api.model.association.PhenotypeAssociation;
+import org.phenopackets.api.model.condition.Phenotype;
+import org.phenopackets.api.model.entity.Disease;
+import org.phenopackets.api.model.ontology.OntologyClass;
+
+public class JsonGeneratorTest {
+
+	private PhenoPacket makePhenoPacket() {
+
+        Disease disease = new Disease();
+        disease.setId("OMIM:101600");
+        disease.setLabel("Pfeiffer syndrome");
+
+		Phenotype p = new Phenotype();
+        p.setTypes(Collections.singletonList(new OntologyClass.Builder("X:1").setLabel("foo").build()));
+		p.setDescription("foo");
+
+		PhenotypeAssociation pa = new PhenotypeAssociation.Builder(p).setEntity(disease).build();
+        return new PhenoPacket.Builder()
+                .addDisease(disease)
+                .addPhenotypeAssociation(pa)
+                .build();
+	}
+
+	@Test
+	public void testCanReadOutputWithoutException() throws Exception {
+		PhenoPacket pk = makePhenoPacket();
+		String jsonString = JsonGenerator.render(pk);
+		InputStream stream = new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8));
+		JsonReader.readInputStream(stream);
+	}
+
+}


### PR DESCRIPTION
This adds a currently failing test of roundtripping JSON output. Something is going wrong with the JSON keys for lists in phenopackets. For example, instead of `phenotype_profile`, the output is writing `phenotypeAssociations`. This was happening before the recent changes I made for output of empty lists. I don't yet know enough about Jackson and builders to fix this.