### PR TITLE
Added annotation for correct serialization of disease_occurrence key.

### DIFF
--- a/src/main/java/org/phenopackets/api/model/association/DiseaseOccurrenceAssociation.java
+++ b/src/main/java/org/phenopackets/api/model/association/DiseaseOccurrenceAssociation.java
@@ -30,6 +30,7 @@ public class DiseaseOccurrenceAssociation implements Association {
     /**
      * @return the disease
      */
+    @JsonProperty("disease_occurrence")
     public DiseaseOccurrence getDiseaseOcurrence() {
         return diseaseOccurrence;
     }


### PR DESCRIPTION
Anytime there is a key containing an underscore we need to make sure the JSON annotation is in both the builder and the domain object.