### PR TITLE
Add static builder methods, including copy constructor

### DIFF
--- a/src/main/java/org/phenopackets/api/PhenoPacket.java
+++ b/src/main/java/org/phenopackets/api/PhenoPacket.java
@@ -1,5 +1,7 @@
 package org.phenopackets.api;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
 
@@ -71,7 +73,7 @@ public class PhenoPacket {
     private final List<VariantAssociation> variantAssociations;
     private final List<EnvironmentAssociation> environmentAssociations;
 
-    private PhenoPacket(Builder builder) {
+    private PhenoPacket(final Builder builder) {
         id = builder.id;
         title = builder.title;
         context = builder.context;
@@ -165,18 +167,35 @@ public class PhenoPacket {
     @JsonInclude(Include.NON_EMPTY)
     @JsonProperty("variant_profile")
     public List<VariantAssociation> getVariantAssociations() {
-		return variantAssociations;
-	}
+        return variantAssociations;
+    }
 
-	public static class Builder {
+    /**
+     * Create and return a new phenopacket builder.
+     *
+     * @return a new phenopacket builder
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
 
+    /**
+     * Create and return a new builder initialized from the fields in the specified phenopacket.
+     *
+     * @param phenoPacket phenopacket to initialize from, must not be null
+     * @return a new phenopacket builder initialized from the fields in the specified phenopacket
+     */
+    public static Builder newBuilder(final PhenoPacket phenoPacket) {
+        return new Builder(phenoPacket);
+    }
+
+    public static class Builder {
         @JsonProperty
         private String id;
         @JsonProperty
         private String title;
         @JsonProperty("@context")
         private Object context;
-       
 
         // ---- ENTITIES ----
         @JsonProperty
@@ -214,22 +233,44 @@ public class PhenoPacket {
             this.variantAssociations = new ArrayList<>();
         }
 
-        public Builder id(String id) {
+        /**
+         * Create a new phenopacket builder initialized from the fields in the specified phenopacket.
+         *
+         * @param phenoPacket phenopacket to initialize from, must not be null
+         */
+        public Builder(final PhenoPacket phenoPacket) {
+            checkNotNull(phenoPacket);
+            this.id = phenoPacket.getId();
+            this.title = phenoPacket.getTitle();
+            this.context = phenoPacket.getContext();
+
+            this.variants = ImmutableList.copyOf(phenoPacket.getVariants());
+            this.persons = ImmutableList.copyOf(phenoPacket.getPersons());
+            this.organisms = ImmutableList.copyOf(phenoPacket.getOrganisms());
+            this.diseases = ImmutableList.copyOf(phenoPacket.getDiseases());
+
+            this.phenotypeAssociations = ImmutableList.copyOf(phenoPacket.getPhenotypeAssociations());
+            this.diseaseOccurrenceAssociations = ImmutableList.copyOf(phenoPacket.getDiseaseOccurrenceAssociations());
+            this.environmentAssociations = ImmutableList.copyOf(phenoPacket.getEnvironmentAssociations());
+            this.variantAssociations = ImmutableList.copyOf(phenoPacket.getVariantAssociations());
+        }
+
+        public Builder id(final String id) {
             this.id = id;
             return this;
         }
 
-        public Builder title(String title) {
+        public Builder title(final String title) {
             this.title = title;
             return this;
         }
         
-        public Builder setContext(Object context) {
+        public Builder context(final Object context) {
         	this.context = context;
         	return this;
         }
 
-        public Builder addVariant(Variant variant) {
+        public Builder addVariant(final Variant variant) {
             variants.add(variant);
             return this;
         }
@@ -237,12 +278,12 @@ public class PhenoPacket {
         /**
          * @param variants the variants to set
          */
-        public Builder setVariants(List<Variant> variants) {
+        public Builder setVariants(final List<Variant> variants) {
             this.variants = variants;
             return this;
         }
 
-        public Builder addPerson(Person person) {
+        public Builder addPerson(final Person person) {
             persons.add(person);
             return this;
         }
@@ -250,12 +291,12 @@ public class PhenoPacket {
         /**
          * @param persons the persons to set
          */
-        public Builder setPersons(List<Person> persons) {
+        public Builder setPersons(final List<Person> persons) {
             this.persons = persons;
             return this;
         }
 
-        public Builder addOrganism(Organism organism) {
+        public Builder addOrganism(final Organism organism) {
             organisms.add(organism);
             return this;
         }
@@ -263,27 +304,27 @@ public class PhenoPacket {
         /**
          * @param organisms the organisms to set
          */
-        public Builder setOrganisms(List<Organism> organisms) {
+        public Builder setOrganisms(final List<Organism> organisms) {
             this.organisms = organisms;
             return this;
         }
 
-        public Builder addDisease(Disease disease) {
+        public Builder addDisease(final Disease disease) {
             diseases.add(disease);
             return this;
         }
 
-        public Builder setDiseases(List<Disease> diseases) {
+        public Builder setDiseases(final List<Disease> diseases) {
             this.diseases = diseases;
             return this;
         }
 
-        public Builder addPhenotypeAssociation(PhenotypeAssociation a) {
+        public Builder addPhenotypeAssociation(final PhenotypeAssociation a) {
             phenotypeAssociations.add(a);
             return this;
         }
 
-        public Builder addVariantAssociation(VariantAssociation a) {
+        public Builder addVariantAssociation(final VariantAssociation a) {
         	variantAssociations.add(a);
             return this;
         }
@@ -291,17 +332,17 @@ public class PhenoPacket {
         /**
          * @param phenotypeAssociations the phenotype_profile to set
          */
-        public Builder setPhenotypeAssociations(List<PhenotypeAssociation> phenotypeAssociations) {
+        public Builder setPhenotypeAssociations(final List<PhenotypeAssociation> phenotypeAssociations) {
             this.phenotypeAssociations = phenotypeAssociations;
             return this;
         }
 
-        public Builder setVariantAssociations(List<VariantAssociation> variantAssociations) {
+        public Builder setVariantAssociations(final List<VariantAssociation> variantAssociations) {
             this.variantAssociations = variantAssociations;
             return this;
         }
 
-        public Builder addDiseaseOccurrenceAssociation(DiseaseOccurrenceAssociation diseaseOccurrenceAssociation) {
+        public Builder addDiseaseOccurrenceAssociation(final DiseaseOccurrenceAssociation diseaseOccurrenceAssociation) {
             this.diseaseOccurrenceAssociations.add(diseaseOccurrenceAssociation);
             return this;
         }
@@ -309,17 +350,17 @@ public class PhenoPacket {
         /**
          * @param diseaseOccurrenceAssociations the diseaseOccurrenceAssociationList to set
          */
-        public Builder setDiseaseOccurrenceAssociations(List<DiseaseOccurrenceAssociation> diseaseOccurrenceAssociations) {
+        public Builder setDiseaseOccurrenceAssociations(final List<DiseaseOccurrenceAssociation> diseaseOccurrenceAssociations) {
             this.diseaseOccurrenceAssociations = diseaseOccurrenceAssociations;
             return this;
         }
 
-        public Builder addEnvironmentAssociation(EnvironmentAssociation environmentAssociation) {
+        public Builder addEnvironmentAssociation(final EnvironmentAssociation environmentAssociation) {
             environmentAssociations.add(environmentAssociation);
             return this;
         }
 
-        public Builder setEnvironmentAssociations(List<EnvironmentAssociation> environmentAssociations) {
+        public Builder setEnvironmentAssociations(final List<EnvironmentAssociation> environmentAssociations) {
             this.environmentAssociations = environmentAssociations;
             return this;
         }
@@ -328,5 +369,4 @@ public class PhenoPacket {
             return new PhenoPacket(this);
         }
     }
-
 }

--- a/src/main/java/org/phenopackets/api/io/RdfGenerator.java
+++ b/src/main/java/org/phenopackets/api/io/RdfGenerator.java
@@ -31,21 +31,9 @@ public class RdfGenerator {
 			throws JsonLdError, JsonProcessingException {
 		PhenoPacket packetWithContext;
 		if (packet.getContext() == null) {
-			// FIXME this cloning is not very future-proof; should be handled by
-			// PhenoPacket class
-			packetWithContext = new PhenoPacket.Builder()
-					.setContext(ContextUtil.defaultContextURI)
-					.id(packet.getId())
-					.title(packet.getTitle())
-					.setDiseaseOccurrenceAssociations(
-							packet.getDiseaseOccurrenceAssociations())
-					.setDiseases(packet.getDiseases())
-					.setEnvironmentAssociations(
-							packet.getEnvironmentAssociations())
-					.setOrganisms(packet.getOrganisms())
-					.setPersons(packet.getPersons())
-					.setVariantAssociations(packet.getVariantAssociations())
-					.setVariants(packet.getVariants()).build();
+			packetWithContext = PhenoPacket.newBuilder(packet)
+                            .context(ContextUtil.defaultContextURI)
+                            .build();
 		} else {
 			packetWithContext = packet;
 		}

--- a/src/test/java/org/phenopackets/api/PhenoPacketTest.java
+++ b/src/test/java/org/phenopackets/api/PhenoPacketTest.java
@@ -1,5 +1,10 @@
 package org.phenopackets.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.phenopackets.api.io.JsonGenerator;
@@ -370,4 +375,116 @@ public class PhenoPacketTest {
         System.out.println(YamlGenerator.render(pk));
     }
 
+    @Test
+    public void testBuilder() {
+        PhenoPacket pk = PhenoPacket.newBuilder()
+            .id("id1")
+            .title("Description of a disease its phenotype and time of onset")
+            .build();
+
+        assertNotNull(pk);
+        assertEquals("id1", pk.getId());
+        assertEquals("Description of a disease its phenotype and time of onset", pk.getTitle());
+        assertNull(pk.getContext());
+        assertTrue(pk.getVariants().isEmpty());
+        assertTrue(pk.getPersons().isEmpty());
+        assertTrue(pk.getOrganisms().isEmpty());
+        assertTrue(pk.getDiseases().isEmpty());
+        assertTrue(pk.getPhenotypeAssociations().isEmpty());
+        assertTrue(pk.getDiseaseOccurrenceAssociations().isEmpty());
+        assertTrue(pk.getEnvironmentAssociations().isEmpty());
+        assertTrue(pk.getVariantAssociations().isEmpty());
+    }
+
+    @Test
+    public void testBuilderInitializedFromPhenoPacket() {
+        Disease disease = getDisease();
+
+        DiseaseOccurrence diseaseOccurrence = getDiseaseOccurrence();
+        DiseaseOccurrenceAssociation diseaseOccurrenceAssociation = new DiseaseOccurrenceAssociation.Builder(diseaseOccurrence)
+            .setEntity(disease)
+            .build();
+
+        Phenotype diseasePhenotype = getDiseasePhenotype();
+        PhenotypeAssociation diseasePhenotypeAssociation = new PhenotypeAssociation.Builder(diseasePhenotype)
+            .setEntity(disease)
+            .build();
+
+        PhenoPacket pk = new PhenoPacket.Builder()
+            .id("id1")
+            .title("Description of a disease its phenotype and time of onset")
+            .addDisease(disease)
+            .addDiseaseOccurrenceAssociation(diseaseOccurrenceAssociation)
+            .addPhenotypeAssociation(diseasePhenotypeAssociation)
+            .build();
+
+        Object context = new Object();
+        PhenoPacket copy = PhenoPacket.newBuilder(pk)
+            .context(context)
+            .build();
+
+        assertNotNull(copy);
+        assertEquals("id1", copy.getId());
+        assertEquals("Description of a disease its phenotype and time of onset", copy.getTitle());
+        assertEquals(context, copy.getContext());
+        assertTrue(copy.getVariants().isEmpty());
+        assertTrue(copy.getPersons().isEmpty());
+        assertTrue(copy.getOrganisms().isEmpty());
+        assertTrue(copy.getDiseases().contains(disease));
+        assertTrue(copy.getPhenotypeAssociations().contains(diseasePhenotypeAssociation));
+        assertTrue(copy.getDiseaseOccurrenceAssociations().contains(diseaseOccurrenceAssociation));
+        assertTrue(copy.getEnvironmentAssociations().isEmpty());
+        assertTrue(copy.getVariantAssociations().isEmpty());
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testBuilderInitializedFromNullPhenoPacket() {
+        PhenoPacket.newBuilder(null);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testBuilderCtrNullPhenoPacket() {
+        new PhenoPacket.Builder(null);
+    }
+
+    @Test
+    public void testBuilderCtrPhenoPacket() {
+        Disease disease = getDisease();
+
+        DiseaseOccurrence diseaseOccurrence = getDiseaseOccurrence();
+        DiseaseOccurrenceAssociation diseaseOccurrenceAssociation = new DiseaseOccurrenceAssociation.Builder(diseaseOccurrence)
+            .setEntity(disease)
+            .build();
+
+        Phenotype diseasePhenotype = getDiseasePhenotype();
+        PhenotypeAssociation diseasePhenotypeAssociation = new PhenotypeAssociation.Builder(diseasePhenotype)
+            .setEntity(disease)
+            .build();
+
+        PhenoPacket pk = new PhenoPacket.Builder()
+            .id("id1")
+            .title("Description of a disease its phenotype and time of onset")
+            .addDisease(disease)
+            .addDiseaseOccurrenceAssociation(diseaseOccurrenceAssociation)
+            .addPhenotypeAssociation(diseasePhenotypeAssociation)
+            .build();
+
+        Object context = new Object();
+        PhenoPacket copy = new PhenoPacket.Builder(pk)
+            .context(context)
+            .build();
+
+        assertNotNull(copy);
+        assertEquals("id1", copy.getId());
+        assertEquals("Description of a disease its phenotype and time of onset", copy.getTitle());
+        assertEquals(context, copy.getContext());
+        assertTrue(copy.getVariants().isEmpty());
+        assertTrue(copy.getPersons().isEmpty());
+        assertTrue(copy.getOrganisms().isEmpty());
+        assertTrue(copy.getDiseases().contains(disease));
+        assertTrue(copy.getPhenotypeAssociations().contains(diseasePhenotypeAssociation));
+        assertTrue(copy.getDiseaseOccurrenceAssociations().contains(diseaseOccurrenceAssociation));
+        assertTrue(copy.getEnvironmentAssociations().isEmpty());
+        assertTrue(copy.getVariantAssociations().isEmpty());
+    }
 }


### PR DESCRIPTION
Fix minor style issues.

Add `Builder(PhenoPacket)` copy ctr to initialize builder.

Add static `newBuilder()` and `newBuilder(PhenoPacket)` methods to match builder style used elsewhere, e.g. Google Guava library.