### PR TITLE
Added contributor and date fields to associations.

### DIFF
--- a/src/main/java/org/phenopackets/api/model/association/Association.java
+++ b/src/main/java/org/phenopackets/api/model/association/Association.java
@@ -24,5 +24,11 @@ public interface Association<T extends Entity> {
     @JsonProperty("evidence")
     @JsonPropertyDescription("Any Association can have any number of pieces of evidence attached")
     public List<Evidence> getEvidence();
+    
+    @JsonProperty("contributor")
+    public String getContributorId();
+    
+    @JsonProperty("date")
+    public String getDate();
 
 }

--- a/src/main/java/org/phenopackets/api/model/association/DiseaseOccurrenceAssociation.java
+++ b/src/main/java/org/phenopackets/api/model/association/DiseaseOccurrenceAssociation.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import org.phenopackets.api.model.association.PhenotypeAssociation.Builder;
 import org.phenopackets.api.model.condition.DiseaseOccurrence;
 import org.phenopackets.api.model.entity.Entity;
 import org.phenopackets.api.model.evidence.Evidence;
@@ -16,18 +17,22 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonDeserialize(builder = DiseaseOccurrenceAssociation.Builder.class)
-@JsonPropertyOrder({"entity", "disease_occurrence", "evidence"})
+@JsonPropertyOrder({"entity", "disease_occurrence", "evidence", "contributor", "date"})
 public class DiseaseOccurrenceAssociation implements Association {
 
     private final DiseaseOccurrence diseaseOccurrence;
     private final String entityId;
     private final List<Evidence> evidences;
+    private final String contributorId;
+	private final String date;
 
 
     private DiseaseOccurrenceAssociation(Builder builder) {
         this.diseaseOccurrence = builder.disease;
         this.entityId = builder.entityId;
         this.evidences = builder.evidence;
+        this.contributorId = builder.contributorId;
+        this.date = builder.date;
     }
 
     /**
@@ -47,6 +52,16 @@ public class DiseaseOccurrenceAssociation implements Association {
     public List<Evidence> getEvidence() {
         return evidences;
     }
+    
+    @Override
+    public String getContributorId() {
+        return contributorId;
+    }
+    
+    @Override
+    public String getDate() {
+        return date;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -55,12 +70,14 @@ public class DiseaseOccurrenceAssociation implements Association {
         DiseaseOccurrenceAssociation that = (DiseaseOccurrenceAssociation) o;
         return Objects.equals(diseaseOccurrence, that.diseaseOccurrence) &&
                 Objects.equals(entityId, that.entityId) &&
-                Objects.equals(evidences, that.evidences);
+                Objects.equals(evidences, that.evidences) &&
+                Objects.equals(contributorId, that.contributorId) &&
+                Objects.equals(date, that.date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(diseaseOccurrence, entityId, evidences);
+        return Objects.hash(diseaseOccurrence, entityId, evidences, contributorId, date);
     }
 
     @Override
@@ -69,6 +86,8 @@ public class DiseaseOccurrenceAssociation implements Association {
                 "diseaseOccurrence=" + diseaseOccurrence +
                 ", entityId='" + entityId + '\'' +
                 ", evidences=" + evidences +
+                ", contributorId=" + contributorId +
+                ", date=" + date +
                 '}';
     }
 
@@ -78,6 +97,10 @@ public class DiseaseOccurrenceAssociation implements Association {
 
         @JsonProperty("entity")
         private String entityId;
+        @JsonProperty("contributor")
+        private String contributorId;
+        @JsonProperty("date")
+        private String date;
         @JsonProperty
         @JsonInclude(Include.NON_EMPTY)
         private List<Evidence> evidence = new ArrayList<>();
@@ -95,6 +118,16 @@ public class DiseaseOccurrenceAssociation implements Association {
         public Builder setEntityId(String entityId) {
             this.entityId = entityId;
             return this;
+        }
+        
+        public Builder setContributorId(String contributorId) {
+        	this.contributorId = contributorId;
+        	return this;
+        }
+        
+        public Builder setDate(String date) {
+        	this.date = date;
+        	return this;
         }
 
         public Builder setEvidence(List<Evidence> evidence) {

--- a/src/main/java/org/phenopackets/api/model/association/EnvironmentAssociation.java
+++ b/src/main/java/org/phenopackets/api/model/association/EnvironmentAssociation.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 
+import org.phenopackets.api.model.association.PhenotypeAssociation.Builder;
 import org.phenopackets.api.model.entity.Entity;
 import org.phenopackets.api.model.environment.Environment;
 import org.phenopackets.api.model.evidence.Evidence;
@@ -24,17 +25,21 @@ import java.util.Objects;
  *
  */
 @JsonDeserialize(builder = EnvironmentAssociation.Builder.class)
-@JsonPropertyOrder({"entity", "environment", "evidence"})
+@JsonPropertyOrder({"entity", "environment", "evidence", "contributor", "date"})
 public class EnvironmentAssociation implements Association {
 	
     @JsonPropertyDescription("The environment which this association is about")
 	private final Environment environment;
 	private final String entityId;
+	private final String contributorId;
+	private final String date;
 	private final List<Evidence> evidence;
 
 	private EnvironmentAssociation(Builder builder) {
 		this.environment = builder.environment;
 		this.entityId = builder.entityId;
+		this.contributorId = builder.contributorId;
+        this.date = builder.date;
 		this.evidence = ImmutableList.copyOf(builder.evidence);
 	}
 	/**
@@ -48,6 +53,16 @@ public class EnvironmentAssociation implements Association {
 	public String getEntityId() {
 		return entityId;
 	}
+	
+	@Override
+    public String getContributorId() {
+        return contributorId;
+    }
+    
+    @Override
+    public String getDate() {
+        return date;
+    }
 
 	@Override
 	public List<Evidence> getEvidence() {
@@ -61,12 +76,14 @@ public class EnvironmentAssociation implements Association {
 		EnvironmentAssociation that = (EnvironmentAssociation) o;
 		return Objects.equals(environment, that.environment) &&
 				Objects.equals(entityId, that.entityId) &&
-				Objects.equals(evidence, that.evidence);
+				Objects.equals(evidence, that.evidence) &&
+                Objects.equals(contributorId, that.contributorId) &&
+                Objects.equals(date, that.date);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(environment, entityId, evidence);
+		return Objects.hash(environment, entityId, evidence, contributorId, date);
 	}
 
 	@Override
@@ -75,7 +92,9 @@ public class EnvironmentAssociation implements Association {
 				"environment=" + environment +
 				", entityId=" + entityId +
 				", evidence=" + evidence +
-				'}';
+				", contributorId=" + contributorId +
+                ", date=" + date +
+                '}';
 	}
 
 	public static class Builder {
@@ -84,6 +103,10 @@ public class EnvironmentAssociation implements Association {
 
         @JsonProperty("entity")
         private String entityId;
+        @JsonProperty("contributor")
+        private String contributorId;
+        @JsonProperty("date")
+        private String date;
         @JsonProperty
         @JsonInclude(Include.NON_EMPTY)
         private List<Evidence> evidence = new ArrayList<>();
@@ -101,6 +124,16 @@ public class EnvironmentAssociation implements Association {
         public Builder setEntityId(String entityId) {
             this.entityId = entityId;
             return this;
+        }
+        
+        public Builder setContributorId(String contributorId) {
+        	this.contributorId = contributorId;
+        	return this;
+        }
+        
+        public Builder setDate(String date) {
+        	this.date = date;
+        	return this;
         }
 
 		public Builder setEvidence(List<Evidence> evidence) {

--- a/src/main/java/org/phenopackets/api/model/association/PhenotypeAssociation.java
+++ b/src/main/java/org/phenopackets/api/model/association/PhenotypeAssociation.java
@@ -17,16 +17,20 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonDeserialize(builder = PhenotypeAssociation.Builder.class)
-@JsonPropertyOrder({"entity", "phenotype", "evidence"})
+@JsonPropertyOrder({"entity", "phenotype", "evidence", "contributor", "date"})
 public class PhenotypeAssociation implements Association {
 	
 	private final Phenotype phenotype;
 	private final String entityId;
+	private final String contributorId;
+	private final String date;
 	private final List<Evidence> evidence;
 
     private PhenotypeAssociation(Builder builder) {
         this.phenotype = builder.phenotype;
         this.entityId = builder.entityId;
+        this.contributorId = builder.contributorId;
+        this.date = builder.date;
         this.evidence = ImmutableList.copyOf(builder.evidence);
     }
 
@@ -37,6 +41,16 @@ public class PhenotypeAssociation implements Association {
     @Override
     public String getEntityId() {
         return entityId;
+    }
+    
+    @Override
+    public String getContributorId() {
+        return contributorId;
+    }
+    
+    @Override
+    public String getDate() {
+        return date;
     }
 
 	@Override
@@ -51,12 +65,14 @@ public class PhenotypeAssociation implements Association {
         PhenotypeAssociation that = (PhenotypeAssociation) o;
         return Objects.equals(phenotype, that.phenotype) &&
                 Objects.equals(entityId, that.entityId) &&
-                Objects.equals(evidence, that.evidence);
+                Objects.equals(evidence, that.evidence) &&
+                Objects.equals(contributorId, that.contributorId) &&
+                Objects.equals(date, that.date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(phenotype, entityId, evidence);
+        return Objects.hash(phenotype, entityId, evidence, contributorId, date);
     }
 
     @Override
@@ -65,6 +81,8 @@ public class PhenotypeAssociation implements Association {
                 "phenotype=" + phenotype +
                 ", entityId=" + entityId +
                 ", evidence=" + evidence +
+                ", contributorId=" + contributorId +
+                ", date=" + date +
                 '}';
     }
 
@@ -74,6 +92,10 @@ public class PhenotypeAssociation implements Association {
 
         @JsonProperty("entity")
         private String entityId;
+        @JsonProperty("contributor")
+        private String contributorId;
+        @JsonProperty("date")
+        private String date;
         @JsonProperty
         @JsonInclude(Include.NON_EMPTY)
         private List<Evidence> evidence = new ArrayList<>();
@@ -91,6 +113,16 @@ public class PhenotypeAssociation implements Association {
         public Builder setEntityId(String entityId) {
             this.entityId = entityId;
             return this;
+        }
+        
+        public Builder setContributorId(String contributorId) {
+        	this.contributorId = contributorId;
+        	return this;
+        }
+        
+        public Builder setDate(String date) {
+        	this.date = date;
+        	return this;
         }
 
         public Builder setEvidence(List<Evidence> evidence) {

--- a/src/main/java/org/phenopackets/api/model/association/VariantAssociation.java
+++ b/src/main/java/org/phenopackets/api/model/association/VariantAssociation.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.phenopackets.api.model.association.PhenotypeAssociation.Builder;
 import org.phenopackets.api.model.entity.Entity;
 import org.phenopackets.api.model.entity.Variant;
 import org.phenopackets.api.model.evidence.Evidence;
@@ -17,16 +18,20 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 
 @JsonDeserialize(builder = VariantAssociation.Builder.class)
-@JsonPropertyOrder({"entity", "variant", "evidence"})
+@JsonPropertyOrder({"entity", "variant", "evidence", "contributor", "date"})
 public class VariantAssociation implements Association {
 
 	private final Variant variant;
 	private final String entityId;
+	private final String contributorId;
+	private final String date;
 	private final List<Evidence> evidence;
 
     private VariantAssociation(Builder builder) {
         this.variant = builder.variant;
         this.entityId = builder.entityId;
+        this.contributorId = builder.contributorId;
+        this.date = builder.date;
         this.evidence = ImmutableList.copyOf(builder.evidence);
     }
 
@@ -37,6 +42,16 @@ public class VariantAssociation implements Association {
     @Override
     public String getEntityId() {
         return entityId;
+    }
+    
+    @Override
+    public String getContributorId() {
+        return contributorId;
+    }
+    
+    @Override
+    public String getDate() {
+        return date;
     }
 
 	@Override
@@ -51,12 +66,14 @@ public class VariantAssociation implements Association {
         VariantAssociation that = (VariantAssociation) o;
         return Objects.equals(variant, that.variant) &&
                 Objects.equals(entityId, that.entityId) &&
-                Objects.equals(evidence, that.evidence);
+                Objects.equals(evidence, that.evidence) &&
+                Objects.equals(contributorId, that.contributorId) &&
+                Objects.equals(date, that.date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(variant, entityId, evidence);
+        return Objects.hash(variant, entityId, evidence, contributorId, date);
     }
 
     @Override
@@ -65,6 +82,8 @@ public class VariantAssociation implements Association {
                 "phenotype=" + variant +
                 ", entityId=" + entityId +
                 ", evidence=" + evidence +
+                ", contributorId=" + contributorId +
+                ", date=" + date +
                 '}';
     }
 
@@ -74,6 +93,10 @@ public class VariantAssociation implements Association {
 
         @JsonProperty("entity")
         private String entityId;
+        @JsonProperty("contributor")
+        private String contributorId;
+        @JsonProperty("date")
+        private String date;
         @JsonProperty
         @JsonInclude(Include.NON_EMPTY)
         private List<Evidence> evidence = new ArrayList<>();
@@ -91,6 +114,16 @@ public class VariantAssociation implements Association {
         public Builder setEntityId(String entityId) {
             this.entityId = entityId;
             return this;
+        }
+        
+        public Builder setContributorId(String contributorId) {
+        	this.contributorId = contributorId;
+        	return this;
+        }
+        
+        public Builder setDate(String date) {
+        	this.date = date;
+        	return this;
         }
 
         public Builder setEvidence(List<Evidence> evidence) {

--- a/src/main/resources/phenopacket-context.jsonld
+++ b/src/main/resources/phenopacket-context.jsonld
@@ -52,6 +52,8 @@
     "filler": "pheno:filler",
     "stressor": "pheno:stressor",
     "transportPath": "pheno:transportPath",
+    "contributor": "dc:contributor",
+    "date": "dc:date",
     
     "dc": "http://purl.org/dc/terms/",
     "EFO" : "http://purl.obolibrary.org/obo/EFO_",


### PR DESCRIPTION
This addresses #69. The results look like this:

``` yaml

---
id: "http://model.geneontology.org/ec9502c7-dfc5-45b0-9208-db22db2497bc"
title: "OMIM-100800.tsv"
diseases:
- id: "http://purl.obolibrary.org/obo/OMIM_100800"
  label: "ACHONDROPLASIA"
'@context': "http://phenopackets.org/context"
phenotype_profile:
- entity: "http://purl.obolibrary.org/obo/OMIM_100800"
  phenotype:
    types:
    - id: "http://purl.obolibrary.org/obo/HP_0003032"
      label: "Short femoral neck"
  evidence:
  - types:
    - id: "http://purl.obolibrary.org/obo/ECO_0000501"
      label: "IEA"
  contributor: "http://orcid.org/0000-0002-0736-9199"
  date: "2009-02-17"
```

What do you think @cmungall? 

One issue unrelated to the format design is that there is an awful lot of duplicated code between the different types of associations. Not sure of the best design with the builders, etc.
